### PR TITLE
Choose analyzable JRE

### DIFF
--- a/src/main/java/soot/ModulePathSourceLocator.java
+++ b/src/main/java/soot/ModulePathSourceLocator.java
@@ -243,7 +243,7 @@ public class ModulePathSourceLocator extends SourceLocator {
   }
 
   public static Path getRootModulesPathOfJDK() {
-    Path p = Paths.get(URI.create("jrt:/"));
+    Path p = G.v().jdkFileSystem.getPath("/");
     if (p.endsWith("modules")) {
       return p;
     }

--- a/src/main/java/soot/ModuleScene.java
+++ b/src/main/java/soot/ModuleScene.java
@@ -151,7 +151,7 @@ public class ModuleScene extends Scene {
     StringBuilder sb = new StringBuilder();
 
     // test for java 9
-    File rtJar = Paths.get(System.getProperty("java.home"), "lib", "jrt-fs.jar").toFile();
+    File rtJar = Paths.get(G.v().getJdkInfo().getPath(), "lib", "jrt-fs.jar").toFile();
     if ((rtJar.exists() && rtJar.isFile()) || !Options.v().soot_modulepath().isEmpty()) {
       sb.append(ModulePathSourceLocator.DUMMY_CLASSPATH_JDK9_FS);
     } else {

--- a/src/main/java/soot/Scene.java
+++ b/src/main/java/soot/Scene.java
@@ -755,7 +755,7 @@ public class Scene {
    * @return the default class path (or null if none could be found)
    */
   public static String defaultJavaClassPath() {
-    final String javaHome = System.getProperty("java.home");
+    final String javaHome = G.v().getJdkInfo().getPath();
     StringBuilder sb = new StringBuilder();
     if ("Mac OS X".equals(System.getProperty("os.name"))) {
       // in older Mac OS X versions, rt.jar was split into classes.jar and
@@ -772,7 +772,7 @@ public class Scene {
       }
     }
     // behavior for Java versions >=9, which do not have a rt.jar file
-    final boolean javaGEQ9 = isJavaGEQ9(System.getProperty("java.version"));
+    final boolean javaGEQ9 = G.v().getJdkInfo().getVersion() >= 9;
     if (javaGEQ9) {
       sb.append(ModulePathSourceLocator.DUMMY_CLASSPATH_JDK9_FS);
       // this is a new basic class in java >= 9 that needs to be laoded

--- a/src/main/java/soot/jimple/toolkits/typing/fast/TypeResolver.java
+++ b/src/main/java/soot/jimple/toolkits/typing/fast/TypeResolver.java
@@ -215,13 +215,7 @@ public class TypeResolver {
         return op;
       }
 
-      boolean needCast = false;
-      if (useType instanceof PrimType && t instanceof PrimType) {
-        if (t.isAllowedInFinalCode() && useType.isAllowedInFinalCode()) {
-          needCast = true;
-        }
-      }
-      if (!needCast && this.h.ancestor(useType, t)) {
+      if (this.h.ancestor(useType, t)) {
         return op;
       }
 

--- a/src/test/java/soot/asm/backend/StoresTest.java
+++ b/src/test/java/soot/asm/backend/StoresTest.java
@@ -33,6 +33,7 @@ import org.objectweb.asm.util.TraceClassVisitor;
  *
  */
 
+
 public class StoresTest extends AbstractASMBackendTest {
 
   @Override
@@ -132,27 +133,24 @@ public class StoresTest extends AbstractASMBackendTest {
       Label l0 = new Label();
       mv.visitJumpInsn(IFLE, l0);
       mv.visitInsn(ICONST_1);
-      mv.visitVarInsn(ISTORE, 0);
+      mv.visitVarInsn(ISTORE, 1);
       Label l1 = new Label();
       mv.visitJumpInsn(GOTO, l1);
 
       mv.visitLabel(l0);
       mv.visitInsn(ICONST_0);
-      mv.visitVarInsn(ISTORE, 0);
+      mv.visitVarInsn(ISTORE, 1);
 
       mv.visitLabel(l1);
-      mv.visitLdcInsn(new Integer(2343249));
-      mv.visitInsn(I2B);
       mv.visitTypeInsn(NEW, "java/lang/Object");
-      mv.visitVarInsn(ASTORE, 1);
-      mv.visitVarInsn(ALOAD, 1);
+      mv.visitVarInsn(ASTORE, 0);
+      mv.visitVarInsn(ALOAD, 0);
       mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
       mv.visitInsn(ICONST_3);
       mv.visitIntInsn(NEWARRAY, T_INT);
       mv.visitInsn(ICONST_1);
       mv.visitLdcInsn(new Integer(24355764));
       mv.visitInsn(IASTORE);
-      mv.visitVarInsn(ISTORE, 2);
       mv.visitFieldInsn(GETSTATIC, "java/lang/System", "out", "Ljava/io/PrintStream;");
       mv.visitTypeInsn(NEW, "java/lang/StringBuilder");
       mv.visitInsn(DUP);
@@ -171,9 +169,10 @@ public class StoresTest extends AbstractASMBackendTest {
       mv.visitLdcInsn("");
       mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/StringBuilder", "append", "(Ljava/lang/String;)Ljava/lang/StringBuilder;",
           false);
-      mv.visitVarInsn(ILOAD, 0);
+      mv.visitVarInsn(ILOAD, 1);
       mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/StringBuilder", "append", "(Z)Ljava/lang/StringBuilder;", false);
-      mv.visitVarInsn(ILOAD, 2);
+      mv.visitLdcInsn(new Integer(2343249));
+      mv.visitInsn(I2B);
       mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/StringBuilder", "append", "(I)Ljava/lang/StringBuilder;", false);
       mv.visitLdcInsn(new Long(314435665L));
       mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/StringBuilder", "append", "(J)Ljava/lang/StringBuilder;", false);
@@ -182,7 +181,7 @@ public class StoresTest extends AbstractASMBackendTest {
       mv.visitLdcInsn(" ");
       mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/StringBuilder", "append", "(Ljava/lang/String;)Ljava/lang/StringBuilder;",
           false);
-      mv.visitVarInsn(ALOAD, 1);
+      mv.visitVarInsn(ALOAD, 0);
       mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/StringBuilder", "append", "(Ljava/lang/Object;)Ljava/lang/StringBuilder;",
           false);
       mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/StringBuilder", "toString", "()Ljava/lang/String;", false);


### PR DESCRIPTION
Reverted internal Soot change, because it led to unnecessary casts on primitive types.