### PR TITLE
Fix exceptional graph building

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.soot-oss</groupId>
     <artifactId>soot-utbot-fork</artifactId>
     <name>Soot - a J*va Optimization Framework</name>
-    <version>4.4.0-FORK-1</version>
+    <version>4.4.0-FORK-2</version>
     <description>A Java Optimization Framework</description>
     <url>https://soot-oss.github.io/soot</url>
     <organization>

--- a/src/main/java/soot/toolkits/graph/ExceptionalUnitGraph.java
+++ b/src/main/java/soot/toolkits/graph/ExceptionalUnitGraph.java
@@ -437,9 +437,9 @@ public class ExceptionalUnitGraph extends UnitGraph implements ExceptionalGraph<
             if (thrower == entryPoint) {
               trapsThatAreHeads.add(catcher);
             }
-            for (Unit pred : throwersPreds) {
-              addEdge(unitToSuccs, unitToPreds, pred, catcher);
-            }
+//            for (Unit pred : throwersPreds) {
+//              addEdge(unitToSuccs, unitToPreds, pred, catcher);
+//            }
           }
           if (alwaysAddSelfEdges || (selfThrowables != null && selfThrowables.catchableAs(trapsType))) {
             addEdge(unitToSuccs, unitToPreds, thrower, catcher);


### PR DESCRIPTION
Soot had a strange code which was adding extra exceptional successors to the predecessors of the throwing stmt. I removed this code.